### PR TITLE
Update context.py

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -846,7 +846,7 @@ class Context:
 
             elif schema.functions[lower_name] != f:
                 raise ValueError(
-                    "Registering different functions with the same name is not allowed"
+                    "Registering multiple functions with the same name is only permitted when the parameter \"replace=True\" is used."
                 )
 
         schema.function_lists.append(


### PR DESCRIPTION
Updating the error message so that the user understands that if they use the same function name to register a new function, they should use replace=True as a parameter.